### PR TITLE
Update DropboxChooser.js

### DIFF
--- a/DropboxChooser.js
+++ b/DropboxChooser.js
@@ -1,10 +1,10 @@
 'use strict';
 
-let LinkingIOS = require('LinkingIOS');
 let qs = require('qs');
 let React = require('react-native');
 let {
-  NativeModules
+  NativeModules,
+  LinkingIOS,
 } = React;
 
 


### PR DESCRIPTION
React .17 requires LinkingIOS to be imported from React.
