### PR TITLE
Use Linking instead of deprecated LinkingIOS

### DIFF
--- a/DropboxChooser.js
+++ b/DropboxChooser.js
@@ -4,7 +4,7 @@ let qs = require('qs');
 let React = require('react-native');
 let {
   NativeModules,
-  LinkingIOS,
+  Linking,
 } = React;
 
 
@@ -23,16 +23,17 @@ class DropboxClient {
     this.appId = options.appId || '';
     this.onFiles = options.onFiles;
 
-    let url = LinkingIOS.popInitialURL();
-    if (url) {
-     this.processURL({ url });
-    }
+    var url = Linking.getInitialURL().then((url) => {
+      if (url) {
+        this.processURL({ url });
+      }
+    }).catch(err => console.error('An error occurred', err));
 
-    LinkingIOS.addEventListener('url', this.processURL);
+    Linking.addEventListener('url', this.processURL);
   }
 
   remove () {
-    LinkingIOS.removeEventListener('url', this.processURL);
+    Linking.removeEventListener('url', this.processURL);
   }
 
   openChooser(type) {
@@ -68,7 +69,7 @@ class DropboxClient {
       }
       catch (e){}
     };
-    
+
     if (files && this.onFiles) {
     	this.onFiles(files);
     };


### PR DESCRIPTION
LinkingIOS is deprecated (https://facebook.github.io/react-native/docs/linkingios.html#content) so i've replaced it with Linking, which is the recommended way.
